### PR TITLE
Dont fail on info

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func failf(msg string, args ...interface{}) {
 
 func hasAnalyzeError(cmdOutput string) bool {
 	// example: error • Undefined class 'function' • lib/package.dart:3:1 • undefined_class
-	analyzeErrorPattern := regexp.MustCompile(`error.+\.dart.\s*`)
+	analyzeErrorPattern := regexp.MustCompile(`error.+\.dart:\d+:\d+`)
 	if analyzeErrorPattern.MatchString(cmdOutput) {
 		return true
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -17,13 +17,15 @@ func TestHasAnalyzeError(t *testing.T) {
 			info • Unused import: 'package:silkthread/service/ads_manager.dart' • lib/pages/post/image_edit.dart:8:8 • unused_import
 			info • Unused import: 'dart:ui' • lib/pages/post/image_full_view.dart:1:8 • unused_import
 			info • Unused import: 'package:cloud_firestore/cloud_firestore.dart' • lib/pages/post/image_full_view.dart:4:8 • unused_import
-			info • Unused import: 'package:font_awesome_flutter/font_awesome_flutter.dart' • lib/pages/post/image_full_view.dart:6:8 • unused_import`,
+			info • Unused import: 'package:font_awesome_flutter/font_awesome_flutter.dart' • lib/pages/post/image_full_view.dart:6:8 • unused_import
+			`,
 			false,
 		},
 		{
 			"contains error level violation",
 			`info • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
-			error • Expected to find ';' • lib/package.dart:3:8 • expected_token`,
+			error • Expected to find ';' • lib/package.dart:3:8 • expected_token
+			`,
 			true,
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestHasAnalyzeError(t *testing.T) {
+	cases := []struct {
+		title     string
+		cmdOutput string
+		want      bool
+	}{
+		{
+			"no error level violation",
+			`info • This class inherits from a class marked as @immutable, and therefore should be immutable (all instance fields must be final) • lib/pages/home/home_page.dart:17:7 • must_be_immutable
+			info • This class inherits from a class marked as @immutable, and therefore should be immutable (all instance fields must be final) • lib/pages/login/login_page.dart:11:7 • must_be_immutable
+			info • Unused import: 'package:silkthread/service/ads_manager.dart' • lib/pages/post/image_edit.dart:8:8 • unused_import
+			info • Unused import: 'dart:ui' • lib/pages/post/image_full_view.dart:1:8 • unused_import
+			info • Unused import: 'package:cloud_firestore/cloud_firestore.dart' • lib/pages/post/image_full_view.dart:4:8 • unused_import
+			info • Unused import: 'package:font_awesome_flutter/font_awesome_flutter.dart' • lib/pages/post/image_full_view.dart:6:8 • unused_import`,
+			false,
+		},
+		{
+			"contains error level violation",
+			`info • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
+			error • Expected to find ';' • lib/package.dart:3:8 • expected_token`,
+			true,
+		},
+	}
+
+	for _, tt := range cases {
+		if got := hasAnalyzeError(tt.cmdOutput); got != tt.want {
+			t.Errorf("%s: got %t want %t", tt.title, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Flutter static analyzer returns with non-zero exit code, even if there are "info" level issues only.

According to the related Flutter ticket (https://github.com/flutter/flutter/issues/20855) this can't be turned off right now, so we implemented a workaround.

Very simple idea: test the output against a proper regexp.