### PR TITLE
Fail only for errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,11 +60,9 @@ func main() {
 	fmt.Println()
 	
 	if err := analyzeCmd.Run(); err != nil {
-		log.Errorf("Error running flutter analyze: %s", err)
-		os.Exit(1)
-	}
-
-	if hasAnalyzeError(b.String()) {
-		os.Exit(1)
+		if hasAnalyzeError(b.String()) {
+			log.Errorf("Error running flutter analyze: %s", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	
 	if err := analyzeCmd.Run(); err != nil {
 		if hasAnalyzeError(b.String()) {
-			log.Errorf("Error running flutter analyze: %s", err)
+			log.Errorf("flutter analyze found errors: %s", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
This fixes #6. It's a continuation of 558fc61b48acca823bf23ef8af63446f177dbb5e. A small logic change was needed to prevent failing the step for informational messages. This is a workaround for a problem in flutter analyze. The root problem is that flutter analyze fails with exit code 1: https://github.com/flutter/flutter/issues/20855
