### PR TITLE
[STEP-11]: Fix error log regex matching

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func failf(msg string, args ...interface{}) {
 }
 
 func constructRegex(severityPattern string) *regexp.Regexp {
-	pattern := fmt.Sprintf(`^%s.+\.dart:\d+:\d+`, severityPattern)
+	pattern := fmt.Sprintf(`^%s .+\.dart:\d+:\d+`, severityPattern)
 	return regexp.MustCompile(pattern)
 }
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
@@ -13,10 +14,18 @@ import (
 	shellquote "github.com/kballard/go-shellquote"
 )
 
+const (
+	errorLevel   = "error"
+	warningLevel = "warning"
+	infoLevel    = "info"
+
+	newLine = "\n"
+)
+
 var severityRegExp = map[string]string{
-	"error":   "error",
-	"warning": "(error|warning)",
-	"info":    "(error|warning|info)",
+	errorLevel:   "error",
+	warningLevel: "(error|warning)",
+	infoLevel:    "(error|warning|info)",
 }
 
 type config struct {
@@ -30,17 +39,27 @@ func failf(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
+func constructRegex(severityPattern string) *regexp.Regexp {
+	pattern := fmt.Sprintf(`^%s.+\.dart:\d+:\d+`, severityPattern)
+	return regexp.MustCompile(pattern)
+}
+
 func hasAnalyzeError(cmdOutput string, failSeverity string) bool {
 	// example: error • Undefined class 'function' • lib/package.dart:3:1 • undefined_class
-	severityPattern := severityRegExp[failSeverity]
-	pattern := fmt.Sprintf(`%s.+\.dart:\d+:\d+`, severityPattern)
-	analyzeErrorPattern := regexp.MustCompile(pattern)
-	return analyzeErrorPattern.MatchString(cmdOutput)
+	outputLines := strings.Split(cmdOutput, newLine)
+	analyzeErrorPattern := constructRegex(severityRegExp[failSeverity])
+
+	for _, line := range outputLines {
+		if analyzeErrorPattern.MatchString(strings.TrimSpace(line)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func hasOtherError(cmdOutput string) bool {
-	analyzeErrorPattern := regexp.MustCompile(`(error|warning|info).+\.dart:\d+:\d+`)
-	return !analyzeErrorPattern.MatchString(cmdOutput)
+	return !hasAnalyzeError(cmdOutput, infoLevel)
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -11,64 +12,115 @@ func TestHasAnalyzeError(t *testing.T) {
 		failSeverity string
 		want         bool
 	}{
+		// Info severity
 		{
-			"no error level violation fails on info",
-			`info • This class inherits from a class marked as @immutable, and therefore should be immutable (all instance fields must be final) • lib/pages/home/home_page.dart:17:7 • must_be_immutable
-			info • This class inherits from a class marked as @immutable, and therefore should be immutable (all instance fields must be final) • lib/pages/login/login_page.dart:11:7 • must_be_immutable
-			info • Unused import: 'package:silkthread/service/ads_manager.dart' • lib/pages/post/image_edit.dart:8:8 • unused_import
-			info • Unused import: 'dart:ui' • lib/pages/post/image_full_view.dart:1:8 • unused_import
-			info • Unused import: 'package:cloud_firestore/cloud_firestore.dart' • lib/pages/post/image_full_view.dart:4:8 • unused_import
-			info • Unused import: 'package:font_awesome_flutter/font_awesome_flutter.dart' • lib/pages/post/image_full_view.dart:6:8 • unused_import
-			`,
-			"warning",
+			"Given info severity and info message that not contains the protected word info when the output is validated then expect to be fail",
+			createFailMessage(infoLevel, ""),
+			infoLevel,
+			true,
+		},
+		{
+			"Given info severity and info message that contains the protected word info when the output is validated then expect to be fail",
+			createFailMessage(infoLevel, infoLevel),
+			infoLevel,
+			true,
+		},
+		{
+			"Given info severity and warning message that not contains the protected word info when the output is validated then expect to be fail",
+			createFailMessage(warningLevel, ""),
+			infoLevel,
+			true,
+		},
+		{
+			"Given info severity and warning message that contains the protected word info when the output is validated then expect to be fail",
+			createFailMessage(warningLevel, infoLevel),
+			infoLevel,
+			true,
+		},
+		{
+			"Given info severity and error message that not contains the protected word info when the output is validated then expect to be fail",
+			createFailMessage(errorLevel, ""),
+			infoLevel,
+			true,
+		},
+		{
+			"Given info severity and error message that contains the protected word info when the output is validated then expect to be fail",
+			createFailMessage(errorLevel, infoLevel),
+			infoLevel,
+			true,
+		},
+		// Warning severity
+		{
+			"Given warning severity and info message that not contains the protected word warning when the output is validated then expect not to be fail",
+			createFailMessage(infoLevel, ""),
+			warningLevel,
 			false,
 		},
 		{
-			"contains error and info level violation fails on error",
-			`info • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
-			error • Expected to find ';' • lib/package.dart:3:8 • expected_token
-			`,
-			"error",
-			true,
-		},
-		{
-			"contains error and info level violation fails on warning",
-			`info • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
-			error • Expected to find ';' • lib/package.dart:3:8 • expected_token
-			`,
-			"warning",
-			true,
-		},
-		{
-			"contains error and info level violation fails on info",
-			`info • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
-			error • Expected to find ';' • lib/package.dart:3:8 • expected_token
-			`,
-			"info",
-			true,
-		},
-		{
-			"contains warning level violation fails on error",
-			`warning • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
-			warning • Expected to find ';' • lib/package.dart:3:8 • expected_token
-			`,
-			"error",
+			"Given warning severity and info message that contains the protected word warning when the output is validated then expect not to be fail",
+			createFailMessage(infoLevel, warningLevel),
+			warningLevel,
 			false,
 		},
 		{
-			"contains warning level violation fails on warning",
-			`warning • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
-			warning • Expected to find ';' • lib/package.dart:3:8 • expected_token
-			`,
-			"warning",
+			"Given warning severity and warning message that not contains the protected word warning when the output is validated then expect to be fail",
+			createFailMessage(warningLevel, ""),
+			warningLevel,
 			true,
 		},
 		{
-			"contains warning level violation fails on info",
-			`warning • Unused import: 'dart:math' • lib/package.dart:3:8 • unused_import
-			warning • Expected to find ';' • lib/package.dart:3:8 • expected_token
-			`,
-			"info",
+			"Given warning severity and warning message that contains the protected word warning when the output is validated then expect to be fail",
+			createFailMessage(warningLevel, warningLevel),
+			warningLevel,
+			true,
+		},
+		{
+			"Given warning severity and error message that not contains the protected word warning when the output is validated then expect to be fail",
+			createFailMessage(errorLevel, ""),
+			warningLevel,
+			true,
+		},
+		{
+			"Given warning severity and error message that contains the protected word warning when the output is validated then expect to be fail",
+			createFailMessage(errorLevel, warningLevel),
+			warningLevel,
+			true,
+		},
+		// Error severity
+		{
+			"Given error severity and info message that not contains the protected word error when the output is validated then expect not to be fail",
+			createFailMessage(infoLevel, ""),
+			errorLevel,
+			false,
+		},
+		{
+			"Given error severity and info message that contains the protected word error when the output is validated then expect not to be fail",
+			createFailMessage(infoLevel, errorLevel),
+			errorLevel,
+			false,
+		},
+		{
+			"Given error severity and warning message that not contains the protected word error when the output is validated then expect not to be fail",
+			createFailMessage(warningLevel, ""),
+			errorLevel,
+			false,
+		},
+		{
+			"Given error severity and warning message that contains the protected word error when the output is validated then expect not to be fail",
+			createFailMessage(warningLevel, errorLevel),
+			errorLevel,
+			false,
+		},
+		{
+			"Given error severity and error message that not contains the protected word error when the output is validated then expect to be fail",
+			createFailMessage(errorLevel, ""),
+			errorLevel,
+			true,
+		},
+		{
+			"Given error severity and error message that contains the protected word error when the output is validated then expect to be fail",
+			createFailMessage(errorLevel, errorLevel),
+			errorLevel,
 			true,
 		},
 	}
@@ -80,6 +132,15 @@ func TestHasAnalyzeError(t *testing.T) {
 	}
 }
 
+func createFailMessage(failSeverity, protectedWord string) string {
+	dummyFileName := "some_file"
+	if protectedWord != "" {
+		dummyFileName = protectedWord
+	}
+
+	return fmt.Sprintf("%s • lib/%s.dart:1:1", failSeverity, dummyFileName)
+}
+
 func TestHasOtherError(t *testing.T) {
 	cases := []struct {
 		title     string
@@ -89,8 +150,23 @@ func TestHasOtherError(t *testing.T) {
 		{
 			"contains other error",
 			`step failed
-			 failed
+			failed
 			`,
+			true,
+		},
+		{
+			"contains other error containing the protected word 'info'",
+			`big bad info occured`,
+			true,
+		},
+		{
+			"contains other error containing the protected word 'warning'",
+			`big bad warning occured`,
+			true,
+		},
+		{
+			"contains other error containing the protected word 'error'",
+			`big bad error occured`,
 			true,
 		},
 		{


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-11

### What?
Error log validating regex changed to match only the start of the messages. New tests implemented to cover the extended logic and existing tests refactored to be compliant with the new tests.

### Why?
The regex previously used to check whether the given error message is coming from the `flutter analyzer` process, or from the command itself, was trying to match the inner parts too of the message for the protected word.

This resulted in a false positive in some cases, for instance:
- the severity is `error` (do not fail on `info` and `warning` messages, only on `error`)
- the fail message is `info` and it contains the protected word `error` (the protected word is the criteria by the regex tries to match)

In this case `info • lib/error_response.dart:1:1` was matching the regex, because it contains the protected word `error`. However, it should not, because `error` is contained in the file name, not in the severity of the message, which is `info`.

### How?
The solution was to change the regex to try matching only the start of the messages, in order to avoid the false positives caused by the inner occurrences of the protected word.